### PR TITLE
Add Vercel config and analyze function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,12 @@ npm run dev
 npm run build
 ```
 
+## Environment variables
+
+The `/api/analyze` endpoint uses OpenAI and requires the following variable:
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENAI_API_KEY` | Token used to authenticate requests to OpenAI. |
+
 For more information and support, please contact Base44 support at app@base44.com.

--- a/api/analyze.js
+++ b/api/analyze.js
@@ -1,0 +1,30 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { text } = req.body || {};
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Missing OPENAI_API_KEY' });
+  }
+
+  try {
+    const openaiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: text || '' }]
+      })
+    });
+
+    const data = await openaiRes.json();
+    return res.status(200).json(data);
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to contact OpenAI' });
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "routes": [
+    { "src": "/api/analyze", "dest": "api/analyze.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` with custom build and output settings
- implement `/api/analyze` serverless function calling OpenAI
- document `OPENAI_API_KEY` env variable in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887bfda6798832a958ca37d94f1385e