### PR TITLE
Add files for easier Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+.env

--- a/README.md
+++ b/README.md
@@ -16,6 +16,28 @@ npm run dev
 npm run build
 ```
 
+## Deploying to Vercel
+
+The project can be deployed as a static site with API functions on
+[Vercel](https://vercel.com). A basic configuration is provided via
+`vercel.json` and `requirements.txt`.
+
+1. Install the Vercel CLI:
+
+   ```bash
+   npm i -g vercel
+   ```
+
+2. Link your project and deploy:
+
+   ```bash
+   vercel
+   ```
+
+The build command runs `npm run build` and outputs the production files to the
+`dist` folder. Python files in the `api` directory are deployed as serverless
+functions using Python 3.11 with dependencies from `requirements.txt`.
+
 For more information and support, please contact Base44 support at app@base44.com.
 
 ## Video analysis script

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+opencv-python
+openai>=1.0

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "functions": {
+    "api/**/*.py": {
+      "runtime": "python3.11"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- include a `.gitignore`
- add a `vercel.json` config for Vercel
- document Vercel deployment steps in README
- list Python dependencies for API functions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6887f1bfdcb8832a83a2fd2da4e35fb0