### PR TITLE
Fix Vercel build configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",


### PR DESCRIPTION
## Summary
- specify deployment config version in `vercel.json`

## Testing
- `npm install` *(fails: 403 Forbidden – registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887f4c53dac832a92f22a8c3831b7ca