### PR TITLE
Fix Python runtime config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,11 @@
 {
+  "version": 2,
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",
   "functions": {
     "api/**/*.py": {
-      "runtime": "python3.11"
+      "runtime": "vercel-python@3.1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- specify the Python runtime with a version in `vercel.json`

## Testing
- `npm install` *(fails: 403 Forbidden – registry access blocked)*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6887f4c53dac832a92f22a8c3831b7ca